### PR TITLE
Use current time as the seed if not specified (Closes: #9)

### DIFF
--- a/Game/dialog/dialog.cpp
+++ b/Game/dialog/dialog.cpp
@@ -4,6 +4,7 @@
 
 #include <QKeyEvent>
 #include <sstream>
+#include <QTime>
 
 Dialog::Dialog(QWidget *parent) :
     QDialog(parent),
@@ -62,6 +63,15 @@ std::unordered_map<QString, QColor> Dialog::getPlayers()
 
 int Dialog::getSeed()
 {
+    if (seed_ == 0) {
+        QTime currentTime = QTime().currentTime();
+        std::string seed = currentTime.toString().toStdString();
+
+        for(unsigned int i=0; i<seed.length(); i++){
+            seed_ += (int)seed[i];
+        }
+    }
+
     return seed_;
 }
 

--- a/Game/dialog/dialog.h
+++ b/Game/dialog/dialog.h
@@ -113,8 +113,8 @@ private:
     QColor pickedColor_;
     int playerCount_ = 0;
     bool playersAdded_ = false;
-    int seed_;
-    int rounds_;
+    int seed_ = 0;
+    int rounds_ = 0;
 };
 
 #endif // DIALOG_H


### PR DESCRIPTION
**Description**
Use current time as the seed if player(s) haven't specified seed in Dialog UI. Also initialize values for some dialog private variables