### PR TITLE
Start game after successful dialog fill up (Closes: #11)

### DIFF
--- a/Game/dialog/dialog.cpp
+++ b/Game/dialog/dialog.cpp
@@ -127,6 +127,7 @@ void Dialog::verifyDialogData()
     int playerCount = players_.size();
 
     if (playerCount == playerCount_) {
+        emit dialogVerified();
         QDialog::accept();
     }
 }

--- a/Game/dialog/dialog.h
+++ b/Game/dialog/dialog.h
@@ -107,6 +107,12 @@ public slots:
      */
     void setRounds();
 
+signals:
+    /**
+     * @brief Custom dialog signal for successful game setup
+     */
+    void dialogVerified();
+
 private:
     Ui::Dialog *ui;
     std::unordered_map<QString, QColor> players_;

--- a/Game/main/mapwindow.cc
+++ b/Game/main/mapwindow.cc
@@ -147,9 +147,12 @@ void MapWindow::resetGame()
     ui_->buildingsOnTile->clear();
     ui_->workersOnTileList->clear();
 
-    settingsDialog_ = std::make_shared<Dialog>();
+    settingsDialog_ = std::make_shared<Dialog>(this);
+    connect(settingsDialog_.get(), SIGNAL(dialogVerified()), this,
+            SLOT(gameButtonClicked()));
+    settingsDialog_->open();
+    settingsDialog_->setWindowModality(Qt::ApplicationModal);
     scoreDialog_ = std::make_shared<ScoreDialog>();
-    settingsDialog_->exec();
 }
 
 void MapWindow::setButtonStateEnabled(const bool state)


### PR DESCRIPTION
**Description**
Implement automatic game start up when dialog has been filled up successfully. Also, removed `Dialog::exec()` as Qt points out that this can lead to some nasty bugs in some cases. `Dialog::open()` should also work asynchronously. Add signal `dialogVerified` as well for distinguishing `QDialog::accept()` and our dialog verified when connected to the game start. 