### PR TITLE
Remove old claim mark and cleanup excessive code (Closes: #15)

### DIFF
--- a/Game/core/gamemanager.cpp
+++ b/Game/core/gamemanager.cpp
@@ -93,11 +93,6 @@ void GameManager::claimArea(MapItem* tile)
     std::shared_ptr<Course::PlayerBase> player = players_.at(currentPlayerIndex_);
     tile->getTileObject()->setOwner(player);
 	player->addObject(tile->getTileObject());
-
-    // Item color based on player's color
-    QColor color = players_.at(currentPlayerIndex_)->getColor();
-    gameScene_->addClaim(tile, color);
-    gameScene_->update(tile->boundingRect());
 }
 
 void GameManager::doTurn()
@@ -134,12 +129,6 @@ void GameManager::doTurn()
             }
         }
     }
-}
-
-void GameManager::updateOwners()
-{
-	// Don't do this, this recalculates everything
-    gameScene_->refreshScene(players_);
 }
 
 void GameManager::calculateScores()
@@ -262,7 +251,6 @@ void GameManager::addBuildingOnTile(MapItem* selectedItem, QString building)
     objectManager_->addBuilding(actualBuilding);
     tile->addBuilding(actualBuilding);
     actualBuilding->onBuildAction();
-    updateOwners();
 
     // Graphics
     selectedItem->setBuildingOnTile(building);
@@ -308,8 +296,7 @@ void GameManager::removeBuildingOnTile(MapItem *selectedItem, std::shared_ptr<Bu
 
 void GameManager::addWorkerOnTile(MapItem *selectedItem, QString worker)
 {
-    if (!selectedItem->claimed() or
-            selectedItem->getTileObject()->getOwner() !=
+    if (selectedItem->getTileObject()->getOwner() !=
                         players_.at(currentPlayerIndex_)) {
         throw Course::OwnerConflict(NOT_OWNED_TILE.toStdString());
     }

--- a/Game/core/gamemanager.hh
+++ b/Game/core/gamemanager.hh
@@ -243,12 +243,6 @@ private:
      * @post Exception guarantee: No-throw
      */
     void doTurn();
-    /**
-     * @brief Updates all the tiles on the map to correct owners
-     * @post Exception guarantee: No-throw
-     * @note Used for buildings that claim tiles
-     */
-    void updateOwners();
 
     /**
      * @brief Calculates the score of the game

--- a/Game/graphics/gamescene.cpp
+++ b/Game/graphics/gamescene.cpp
@@ -216,16 +216,6 @@ void GameScene::calculateBorders()
 
 }
 
-void GameScene::addClaim(MapItem* obj,const QColor &claimColor)
-{
-    obj->setClaimColor(claimColor);
-}
-
-void GameScene::removeClaim(MapItem* obj)
-{
-    obj->setClaimColor("");
-}
-
 void GameScene::highlightTile(MapItem *obj, bool highlightOn)
 {
 	if(obj == nullptr){
@@ -236,33 +226,6 @@ void GameScene::highlightTile(MapItem *obj, bool highlightOn)
 		obj->addHighlight();
 	} else {
 		obj->removeHighlight();
-	}
-}
-
-void GameScene::refreshScene(const std::vector<std::shared_ptr<Player>> &players)
-{
-	QList<QGraphicsItem*> itemList = items();
-
-	for (auto item: itemList) {
-		// Cast and check if the item is MapItem
-		MapItem* trueItem = dynamic_cast<MapItem*>(item);
-		if(trueItem == nullptr){
-			continue;
-		}
-
-		if (trueItem->getTileObject()->getOwner() != nullptr) {
-			// Find owner color
-			std::shared_ptr<Player> player;
-			std::string ownerName = trueItem->getTileObject()->getOwner()->getName();
-
-			for(std::shared_ptr<Player> p : players){
-				if(p->getName() == ownerName){
-					player = p;
-				}
-			}
-			addClaim(trueItem,player->getColor());
-			trueItem->update(trueItem->boundingRect());
-		}
 	}
 }
 

--- a/Game/graphics/gamescene.hh
+++ b/Game/graphics/gamescene.hh
@@ -67,31 +67,12 @@ public:
 	 */
 	void calculateBorders();
 
-    /**
-     * @brief Adds claim for certain object
-     * @param obj to add claim
-     * @param claimColor based on player's color
-     */
-    void addClaim(MapItem* obj, const QColor &claimColor);
-
-    /**
-     * @brief Removes the claim
-     * @param obj to remove the claim from
-     */
-    void removeClaim(MapItem *obj);
-
 	/**
 	 * @brief Highlight the selected tile
 	 * @param obj the item to highlight
 	 * @param highlightOn bool to highlight or not
 	 */
 	void highlightTile(MapItem *obj, bool highlightOn=true);
-
-    /**
-     * @brief Refresh the scene items if they're stuck or won't update
-     * @param Players on the game
-     */
-    void refreshScene(const std::vector<std::shared_ptr<Player>> &players);
 
 protected:
 	void mousePressEvent(QGraphicsSceneMouseEvent *event) override;

--- a/Game/graphics/mapitem.cpp
+++ b/Game/graphics/mapitem.cpp
@@ -11,20 +11,6 @@ MapItem::MapItem(const std::shared_ptr<Course::GameObject> &obj,
 {
     highlightPen_.setWidth(1);
     highlightPen_.setJoinStyle(Qt::MiterJoin);
-
-    claimPen_.setWidth(2);
-}
-
-/*QRectF MapItem::boundingRect() const
-{
-	QPoint topleft = scenePos().toPoint();
-	QPoint bottomright = scenePos().toPoint() + QPoint(size_,size_);
-    return QRectF(topleft,bottomright);
-}*/
-
-bool MapItem::claimed()
-{
-    return claimed_;
 }
 
 void MapItem::paint(QPainter *painter,
@@ -36,7 +22,6 @@ void MapItem::paint(QPainter *painter,
     drawBuildings(painter);
     drawWorkers(painter);
 
-    if(claimColor_ != "") drawClaim(painter);
     if(borderColor_ != "") drawBorder(painter);
     // Draw this after other borders
     if(highlightColor_ != "") drawHighlight(painter);
@@ -137,29 +122,6 @@ void MapItem::drawBorder(QPainter *painter)
         QRectF bounding = boundingRect();
         bounding.setRect(bounding.x()-0.5, bounding.y()-0.5,
                          bounding.width()+0.5, bounding.height()+0.5);
-        painter->drawRect(bounding);
-    }
-}
-
-void MapItem::setClaimColor(const QColor &color)
-{
-    claimPen_.setBrush(color);
-    claimColor_ = color;
-}
-
-QColor MapItem::getClaimColor()
-{
-    return claimColor_;
-}
-
-void MapItem::drawClaim(QPainter *painter)
-{
-    if (claimColor_ != "") {
-        // Adds marker based on player's color
-        claimed_ = true;
-        painter->setPen(claimPen_);
-        QRectF bounding = boundingRect();
-        bounding.setRect(bounding.x()+1,bounding.y()+1,1,1);
         painter->drawRect(bounding);
     }
 }

--- a/Game/graphics/mapitem.hh
+++ b/Game/graphics/mapitem.hh
@@ -28,18 +28,6 @@ public:
     MapItem(const std::shared_ptr<Course::GameObject> &obj, int size);
 
     /**
-     * @brief Calculates the boundings for this item
-     * @return QRectF that bounds the item
-     */
-	//QRectF boundingRect() const;
-
-    /**
-     * @brief Check claimed status
-     * @return Return true if claimed
-     */
-    bool claimed();
-
-    /**
      * @brief Paints the tile, buildings and workers
      * @param painter pointer for painting
      * @param option unused style pointer
@@ -91,18 +79,6 @@ public:
      */
     void removeHighlight();
 
-    /**
-     * @brief Sets claim color
-     * @param Player's color
-     */
-    void setClaimColor(const QColor &color);
-
-    /**
-     * @brief Fetches the claim color for this item
-     * @return Claim color or nullptr if not set
-     */
-    QColor getClaimColor();
-
 private:
     /**
      * @brief Draws the tileImage
@@ -134,21 +110,12 @@ private:
      */
     void drawBorder(QPainter* painter);
 
-    /**
-     * @brief draw the claim
-     * @param painter pointer
-     */
-    void drawClaim(QPainter* painter);
-
     const std::shared_ptr<Course::GameObject> itemObject_;
     int size_;
     QPoint sceneLocation_;
 
     QPixmap currentItem_;
-    bool claimed_ = false;
-    // Shows owner
-    QColor claimColor_ = nullptr;
-    QPen claimPen_;
+
     // Highlighting
     QPen highlightPen_;
     QColor highlightColor_;


### PR DESCRIPTION
**Description**
Remove old claim mark & cleanup for example gamemanager updateOwners() as it has become obsolete. Basically removes everything that has been due to the old claim mark, like scene updates etc. 

See issue #15 for better look. 